### PR TITLE
Add support for artifacts without version numbers

### DIFF
--- a/launcher/src/main/java/org/springframework/boot/loader/thin/PathResolver.java
+++ b/launcher/src/main/java/org/springframework/boot/loader/thin/PathResolver.java
@@ -397,6 +397,7 @@ public class PathResolver {
 			path = path.substring(0, path.length() - 2);
 		}
 		path = StringUtils.getFilename(path);
+		path = path.replace(".jar", "");
 		path = path.split("-[0-9]")[0];
 		return path;
 	}


### PR DESCRIPTION
The thin launcher fails to find the correct pom on jars without the version number in its archive name, therefore causing the dependency resolution to fail.

This PR solves that issue, by sanitizing the `.jar` from the end of the archive name before removing the version, ensuring that it will resolve the archive name correctly.