### PR TITLE
Fix for missing Start-Class attribute error and Gradle 6.8.x support

### DIFF
--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -22,6 +22,10 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-loader</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-loader-tools</artifactId>
 		</dependency>
 		<dependency>

--- a/samples/multi/application/build.gradle
+++ b/samples/multi/application/build.gradle
@@ -6,15 +6,6 @@ plugins {
 	id 'org.springframework.boot.experimental.thin-launcher' version '1.0.27.BUILD-SNAPSHOT'
 }
 
-// Shouldn't need this...
-jar {
-	manifest {
-		attributes(
-			'Start-Class': 'hello.app.DemoApplication'
-		)
-	}
-}
-
 jar {
     baseName = 'application'
     version = '0.0.1-SNAPSHOT'

--- a/samples/other/build.gradle
+++ b/samples/other/build.gradle
@@ -11,15 +11,6 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-// Shouldn't need this...
-jar {
-	manifest {
-		attributes(
-			'Start-Class': 'com.example.LauncherApplication'
-		)
-	}
-}
-
 thinResolvePrepare {
 	into new File("${buildDir}/thin/deploy")
 }

--- a/samples/simple/build.gradle
+++ b/samples/simple/build.gradle
@@ -10,15 +10,6 @@ group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
-// Shouldn't need this...
-jar {
-	manifest {
-		attributes(
-			'Start-Class': 'com.example.LauncherApplication'
-		)
-	}
-}
-
 repositories {
 	mavenLocal()
 	mavenCentral()

--- a/samples/simple/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/simple/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip


### PR DESCRIPTION
Updated ThinLauncherPlugin class implementation to perform the
dependsOn(bootJar) wrapped in project.afterEvaluate() since that task
is not visible during the Gradle task configuration phase. This
resolved the issue for the Start-Class missing error and allows the
plugin to be used in Gradle 6.8.x projects.