### PR TITLE
Update README.md and samples for Spring 2.x and maven-publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spring Boot Thin Launcher [![ci.spring.io](https://ci.spring.io/api/v1/teams/spring-team/pipelines/spring-boot-thin-launcher/badge)](https://ci.spring.io/teams/spring-team/pipelines/spring-boot-thin-launcher)
 
-A "thin" jar launcher for java apps. Version 1.0.25.RELEASE is in Maven Central, snapshots are in https://repo.spring.io/libs-snapshot. See https://github.com/spring-projects/spring-boot/issues/1813 for more discussion and ideas.
+A "thin" jar launcher for java apps. Version 1.0.27.RELEASE is in Maven Central, snapshots are in https://repo.spring.io/libs-snapshot. See https://github.com/spring-projects/spring-boot/issues/1813 for more discussion and ideas.
 
 ## Getting Started
 
@@ -26,19 +26,19 @@ means adding it to the Spring Boot plugin declaration:
 		<dependency>
 			<groupId>org.springframework.boot.experimental</groupId>
 			<artifactId>spring-boot-thin-layout</artifactId>
-			<version>1.0.25.RELEASE</version>
+			<version>1.0.27.RELEASE</version>
 		</dependency>
 	</dependencies>
 </plugin>
 ```
 
-and in Gradle for Spring Boot up to 1.5.x (you can use older versions of Spring Boot for the app, but the plugin has to be 1.5.x or later):
+and in Gradle, you can use the older `apply` style declaration:
 
 ```groovy
 buildscript {
 	ext {
-		springBootVersion = '1.5.6.RELEASE'
-		wrapperVersion = '1.0.25.RELEASE'
+		springBootVersion = '2.2.4.RELEASE'
+		wrapperVersion = '1.0.27.RELEASE'
 	}
 	repositories {
 		mavenLocal()
@@ -49,19 +49,27 @@ buildscript {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
 	}
 }
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'org.springframework.boot.experimental.thin-launcher'
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 ```
 
-For Spring Boot 2.x you can use the newer `id` style declaration:
+Or you can use the newer `id` style declaration:
 
 ```groovy
 plugins {
 	id 'org.springframework.boot' version '2.2.4.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
-	id 'maven'
-	id 'org.springframework.boot.experimental.thin-launcher' version '1.0.25.RELEASE'
+	id 'maven-publish'
+	id 'org.springframework.boot.experimental.thin-launcher' version '1.0.27.RELEASE'
 }
 
 group = 'com.example'
@@ -73,6 +81,14 @@ repositories {
 	mavenCentral()
 	maven { url "https://repo.spring.io/snapshot" }
 	maven { url "https://repo.spring.io/milestone" }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }
 ```
 
@@ -150,7 +166,7 @@ with that class loader. The `pom.xml` can be in the root of the jar or
 in the standard `META-INF/maven` location.
 
 The app jar in the demo is built using the Spring Boot plugin and a
-custom `Layout` (so it only builds with Spring Boot 1.5.x and above).
+custom `Layout` (so it only builds with Spring Boot 2.x and above).
 
 ## Caching JARs
 
@@ -405,7 +421,7 @@ versions, you can change the version of the bom using
 `thin.properties`. E.g.
 
 ```
-boms.spring-boot-dependencies=org.springframework.boot:spring-boot-dependencies:1.5.6.RELEASE
+boms.spring-boot-dependencies=org.springframework.boot:spring-boot-dependencies:2.2.4.RELEASE
 ...
 ```
 
@@ -414,8 +430,8 @@ Spring Boot starter parent), you can change the value of the property
 using `thin.properties`. E.g.
 
 ```
-spring-boot.version=1.5.6.RELEASE
-spring-cloud.version=Dalston.SR3
+spring-boot.version=2.2.4.RELEASE
+spring-cloud.version=Hoxton.SR1
 ```
 
 where the pom has

--- a/locator/build.gradle
+++ b/locator/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 
@@ -46,3 +46,11 @@ dependencies {
 }
 
 jar.dependsOn = [createPom]
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			from components.java
+		}
+	}
+}

--- a/samples/fat/build.gradle
+++ b/samples/fat/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.2.4.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
-	id 'maven'
+	id 'maven-publish'
 }
 
 group = 'com.example'
@@ -25,4 +25,12 @@ dependencies {
 
 test {
 	useJUnitPlatform()
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			from components.java
+		}
+	}
 }

--- a/samples/multi/application/build.gradle
+++ b/samples/multi/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.3.9.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
-	id 'maven'
+	id 'maven-publish'
 	id 'org.springframework.boot.experimental.thin-launcher' version '1.0.27.BUILD-SNAPSHOT'
 }
 
@@ -21,5 +21,13 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-web')
     compile project(':library')
     testCompile('org.springframework.boot:spring-boot-starter-test')
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }
 

--- a/samples/multi/library/build.gradle
+++ b/samples/multi/library/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'maven'
+	id 'maven-publish'
 }
 
 plugins { id "io.spring.dependency-management" version "1.0.4.RELEASE" }
@@ -9,7 +9,7 @@ ext { springBootVersion = '1.5.10.RELEASE' }
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
@@ -28,4 +28,12 @@ dependencies {
 
 dependencyManagement {
     imports { mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion}") }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/samples/other/build.gradle
+++ b/samples/other/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.3.7.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
-	id 'maven'
+	id 'maven-publish'
 	id 'org.springframework.boot.experimental.thin-launcher' version '1.0.27.BUILD-SNAPSHOT'
 }
 
@@ -25,4 +25,12 @@ repositories {
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			from components.java
+		}
+	}
 }

--- a/samples/shadow/build.gradle
+++ b/samples/shadow/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'eclipse'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'com.github.johnrengelman.shadow'
@@ -71,4 +71,12 @@ configurations {
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			from components.java
+		}
+	}
 }

--- a/samples/simple/build.gradle
+++ b/samples/simple/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.2.4.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
-	id 'maven'
+	id 'maven-publish'
 	id 'org.springframework.boot.experimental.thin-launcher' version '1.0.27.BUILD-SNAPSHOT'
 }
 
@@ -40,4 +40,12 @@ dependencyManagement {
 
 test {
 	useJUnitPlatform()
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			from components.java
+		}
+	}
 }


### PR DESCRIPTION
Update README.md to remove references to Spring 1.5.x and use 
"maven-publish" plugin instead of "maven". Updated samples to use
"maven-publish" plugin instead of "maven".