### PR TITLE
Issue #166 - Gradle 7 Compatibility

### DIFF
--- a/gradle-plugin/src/main/java/org/springframework/boot/experimental/gradle/PomTask.java
+++ b/gradle-plugin/src/main/java/org/springframework/boot/experimental/gradle/PomTask.java
@@ -48,7 +48,7 @@ import org.gradle.api.tasks.TaskExecutionException;
 public class PomTask extends DefaultTask {
 
 	@OutputFile
-	private File output;
+	File output;
 
 	@TaskAction
 	public void generate() {


### PR DESCRIPTION
I believe this should either not be private, or else this annotation must be removed entirely affecting cacheability