### PR TITLE
Ensured the explicitly supplied libs are put in front of the class path

### DIFF
--- a/launcher/src/main/java/org/springframework/boot/loader/thin/ThinJarLauncher.java
+++ b/launcher/src/main/java/org/springframework/boot/loader/thin/ThinJarLauncher.java
@@ -387,17 +387,20 @@ public class ThinJarLauncher extends ExecutableArchiveLauncher {
 		if (StringUtils.hasText(parent)) {
 			parentArchive = ArchiveUtils.getArchive(parent);
 		}
-		long t0 = System.currentTimeMillis();
-		List<Archive> archives = resolver.resolve(parentArchive, getArchive(), name,
-				profiles);
-		long t1 = System.currentTimeMillis();
-		if (log.isInfoEnabled()) {
+        if (log.isInfoEnabled()) {
 			if (!this.libs.isEmpty()) {
 				log.info("Adding libraries: " + this.libs);
 			}
+		}
+		// Prepend the explicitly supplied libs to the class path
+        final List<Archive> archives = new ArrayList<>(this.libs);
+		long t0 = System.currentTimeMillis();
+		archives.addAll(resolver.resolve(parentArchive, getArchive(), name,
+				profiles));
+		long t1 = System.currentTimeMillis();
+		if (log.isInfoEnabled()) {
 			log.info("Dependencies resolved in: " + (t1 - t0) + "ms");
 		}
-		archives.addAll(this.libs);
 		return archives;
 	}
 

--- a/launcher/src/main/java/org/springframework/boot/loader/thin/ThinJarLauncher.java
+++ b/launcher/src/main/java/org/springframework/boot/loader/thin/ThinJarLauncher.java
@@ -387,13 +387,13 @@ public class ThinJarLauncher extends ExecutableArchiveLauncher {
 		if (StringUtils.hasText(parent)) {
 			parentArchive = ArchiveUtils.getArchive(parent);
 		}
-        if (log.isInfoEnabled()) {
+		if (log.isInfoEnabled()) {
 			if (!this.libs.isEmpty()) {
 				log.info("Adding libraries: " + this.libs);
 			}
 		}
 		// Prepend the explicitly supplied libs to the class path
-        final List<Archive> archives = new ArrayList<>(this.libs);
+		final List<Archive> archives = new ArrayList<>(this.libs);
 		long t0 = System.currentTimeMillis();
 		archives.addAll(resolver.resolve(parentArchive, getArchive(), name,
 				profiles));


### PR DESCRIPTION
It makes sense to prepend the explicitly supplied libs to the classpath to be able to override auto-resolved dependencies.

This is handy to ensure locally built and/or SNAPSHOT dependencies can be given precedence.